### PR TITLE
Derive basic std traits for `CreateNamespace`

### DIFF
--- a/src/xmlname/create.rs
+++ b/src/xmlname/create.rs
@@ -86,6 +86,7 @@ impl From<CreateName> for NameId {
 ///
 /// You can pass it as an argument into [`CreateName`] to create an object in a
 /// namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CreateNamespace {
     pub(crate) prefix_id: PrefixId,
     pub(crate) namespace_id: NamespaceId,


### PR DESCRIPTION
`xmlname::CreateNamespace` has no `#[derive(..)]`, which seems like a mistake.

This patch adds `#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]` (the list is copied from `CreateName`) to `CreateNamespace` type.