### PR TITLE
Add methods to `NodeEdge` for convenience

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -74,6 +74,36 @@ impl NodeEdge {
             Self::Start(node) | Self::End(node) => node,
         }
     }
+
+    /// Returns the next edge in depth-first traversal order.
+    #[must_use]
+    pub fn next(self, xot: &Xot) -> Option<Self> {
+        match self {
+            Self::Start(current) => xot
+                .first_child(current)
+                .map(Self::Start)
+                .or(Some(Self::End(current))),
+            Self::End(current) => xot
+                .next_sibling(current)
+                .map(Self::Start)
+                .or_else(|| xot.parent(current).map(Self::End)),
+        }
+    }
+
+    /// Returns the previous edge in depth-first traversal order.
+    #[must_use]
+    pub fn previous(self, xot: &Xot) -> Option<Self> {
+        match self {
+            Self::End(current) => xot
+                .last_child(current)
+                .map(Self::End)
+                .or(Some(Self::Start(current))),
+            Self::Start(current) => xot
+                .previous_sibling(current)
+                .map(Self::End)
+                .or_else(|| xot.parent(current).map(Self::Start)),
+        }
+    }
 }
 
 /// ## Read-only access

--- a/src/access.rs
+++ b/src/access.rs
@@ -62,7 +62,7 @@ pub enum NodeEdge {
     /// this is the end tag. In case of document this is the end
     /// of the document. For any other values, the
     /// end edge occurs immediately after the start
-    /// edge.  
+    /// edge.
     End(Node),
 }
 

--- a/src/access.rs
+++ b/src/access.rs
@@ -68,6 +68,21 @@ pub enum NodeEdge {
 
 impl NodeEdge {
     /// Returns the starting or ending node.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let mut xot = xot::Xot::new();
+    /// let root = xot.parse("<p><a/><b><c/></b></p>").unwrap();
+    /// let p = xot.document_element(root).unwrap();
+    /// let a = xot.first_child(p).unwrap();
+    /// let b = xot.next_sibling(a).unwrap();
+    /// let c = xot.first_child(b).unwrap();
+    /// let traversed: Vec<xot::Node> = xot
+    ///     .traverse(p)
+    ///     .map(|edge| edge.node())
+    ///     .collect();
+    /// assert_eq!(traversed, &[p, a, a, b, c, c, b, p]);
     #[must_use]
     pub fn node(self) -> Node {
         match self {
@@ -76,6 +91,27 @@ impl NodeEdge {
     }
 
     /// Returns the next edge in depth-first traversal order.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let mut xot = xot::Xot::new();
+    /// let root = xot.parse("<p><a/><b><c/><d/><e/></b><f><g/><h/></f></p>").unwrap();
+    /// let traversed: Vec<xot::NodeEdge> = xot.traverse(root).collect();
+    ///
+    /// let mut current = xot::NodeEdge::Start(root);
+    /// let mut traversed2 = vec![current];
+    /// while let Some(next) = current.next(&xot) {
+    ///     if let xot::NodeEdge::End(node) = current {
+    ///         // You can use `&mut Xot` inside the loop.
+    ///         xot.remove(node);
+    ///     }
+    ///
+    ///     traversed2.push(next);
+    ///     current = next;
+    /// }
+    /// assert_eq!(traversed, traversed2);
+    /// ```
     #[must_use]
     pub fn next(self, xot: &Xot) -> Option<Self> {
         match self {
@@ -91,6 +127,27 @@ impl NodeEdge {
     }
 
     /// Returns the previous edge in depth-first traversal order.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let mut xot = xot::Xot::new();
+    /// let root = xot.parse("<p><a/><b><c/><d/><e/></b><f><g/><h/></f></p>").unwrap();
+    /// let rev_traversed: Vec<xot::NodeEdge> = xot.reverse_traverse(root).collect();
+    ///
+    /// let mut current = xot::NodeEdge::End(root);
+    /// let mut rev_traversed2 = vec![current];
+    /// while let Some(next) = current.previous(&xot) {
+    ///     if let xot::NodeEdge::Start(node) = current {
+    ///         // You can use `&mut Xot` inside the loop.
+    ///         xot.remove(node);
+    ///     }
+    ///
+    ///     rev_traversed2.push(next);
+    ///     current = next;
+    /// }
+    /// assert_eq!(rev_traversed, rev_traversed2);
+    /// ```
     #[must_use]
     pub fn previous(self, xot: &Xot) -> Option<Self> {
         match self {

--- a/src/access.rs
+++ b/src/access.rs
@@ -66,6 +66,16 @@ pub enum NodeEdge {
     End(Node),
 }
 
+impl NodeEdge {
+    /// Returns the starting or ending node.
+    #[must_use]
+    pub fn node(self) -> Node {
+        match self {
+            Self::Start(node) | Self::End(node) => node,
+        }
+    }
+}
+
 /// ## Read-only access
 ///
 /// These are functions that provide read-only access to the tree.


### PR DESCRIPTION
## `NodeEdge::node()`
To get the node of the interest, users should write `let NodeEdge::Start(node) | NodeEdge::End(node) = edge;` or `match edge { NodeEdge::Start(node) | NodeEdge::End(node) => node }`.
This is worth being a method.

## `NodeEdge::previous()`, `NodeEdge::next()`
These methods returns the next/previous edge (in the order of `all_traverse()` iteration).
Iterators returned by `all_traverse()` and `reverse_traverse()` neither allow skipping some subtrees nor modifying the tree (since the iterator borrows `&Xot` for its lifetime).
With `NodeEdge::next/previous` methods, such skip and modification become possible.