### PR TITLE
Implement `Clone` trait for `Xot` type

### DIFF
--- a/src/id/idmap.rs
+++ b/src/id/idmap.rs
@@ -7,7 +7,7 @@ pub(crate) trait IdIndex<T> {
     fn from_id(id: T) -> usize;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct IdMap<K: Copy + IdIndex<K>, V: Eq + std::hash::Hash + Clone> {
     by_id: Vec<V>,
     by_value: HashMap<V, K>,

--- a/src/manipulation.rs
+++ b/src/manipulation.rs
@@ -587,7 +587,7 @@ impl Xot {
     /// let doc_el = xot.document_element(root)?;
     /// let a_el = xot.first_child(doc_el).unwrap();
     ///
-    /// let cloned = xot.clone(a_el);
+    /// let cloned = xot.clone_node(a_el);
     ///
     /// assert_eq!(xot.to_string(root)?, r#"<doc><a f="F"><b><c/></b></a></doc>"#);
     ///
@@ -599,7 +599,7 @@ impl Xot {
     ///
     /// # Ok::<(), xot::Error>(())
     /// ```
-    pub fn clone(&mut self, node: Node) -> Node {
+    pub fn clone_node(&mut self, node: Node) -> Node {
         let edges = self.all_traverse(node).collect::<Vec<_>>();
 
         // we need to create a top node
@@ -666,7 +666,7 @@ impl Xot {
     ///
     /// // if you do a normal clone, prefixes aren't preserved and need to be generated instead
     ///
-    /// let cloned = xot.clone(a_el);
+    /// let cloned = xot.clone_node(a_el);
     /// xot.create_missing_prefixes(cloned)?;
     /// assert_eq!(xot.to_string(cloned)?, r#"<n0:a xmlns:n0="http://example.com"><n0:b><n0:c/></n0:b></n0:a>"#);
     ///
@@ -676,7 +676,7 @@ impl Xot {
         // get all prefixes defined in scope
         let prefixes = self.inherited_prefixes(node);
 
-        let clone = self.clone(node);
+        let clone = self.clone_node(node);
         // add any prefixes from outer scope we may need
         if self.is_element(clone) {
             let mut namespaces = self.namespaces_mut(clone);

--- a/src/xotdata.rs
+++ b/src/xotdata.rs
@@ -45,7 +45,7 @@ impl From<NodeId> for Node {
 /// * [Parsing](#parsing)
 /// * [Serialization](#serialization)
 /// * [Value and type access](#value-and-type-access)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Xot {
     pub(crate) arena: XmlArena,
     pub(crate) namespace_lookup: NamespaceLookup,

--- a/tests/test_manip.rs
+++ b/tests/test_manip.rs
@@ -350,7 +350,7 @@ fn test_clone() {
     let root = xot.parse(r#"<doc><a>Hello!</a></doc>"#).unwrap();
     let doc_id = xot.document_element(root).unwrap();
     let a_id = xot.first_child(doc_id).unwrap();
-    let a_id_clone = xot.clone(a_id);
+    let a_id_clone = xot.clone_node(a_id);
     // change original won't affect the clone
     xot.text_mut(xot.first_child(a_id).unwrap())
         .unwrap()
@@ -367,7 +367,7 @@ fn test_clone() {
 fn test_clone_root() {
     let mut xot = Xot::new();
     let root = xot.parse(r#"<doc><a>Hello!</a></doc>"#).unwrap();
-    let root_clone = xot.clone(root);
+    let root_clone = xot.clone_node(root);
     assert_eq!(
         xot.to_string(root_clone).unwrap(),
         r#"<doc><a>Hello!</a></doc>"#
@@ -383,7 +383,7 @@ fn test_clone_root_after_insert() {
     let i = xot.next_sibling(txt).unwrap();
     let new_node = xot.new_text("?");
     xot.insert_after(i, new_node).unwrap();
-    let root_clone = xot.clone(root);
+    let root_clone = xot.clone_node(root);
     assert_eq!(
         xot.to_string(root_clone).unwrap(),
         "<doc>hello <i>world</i>?!</doc>"
@@ -400,7 +400,7 @@ fn test_clone_root_after_insert_no_consolidation() {
     let i = xot.next_sibling(txt).unwrap();
     let new_node = xot.new_text("?");
     xot.insert_after(i, new_node).unwrap();
-    let root_clone = xot.clone(root);
+    let root_clone = xot.clone_node(root);
     xot.set_text_consolidation(true);
     assert_eq!(
         xot.to_string(root_clone).unwrap(),
@@ -419,7 +419,7 @@ fn test_clone_root_after_insert_no_consolidation_for_insert_consolidation_for_cl
     let new_node = xot.new_text("?");
     xot.insert_after(i, new_node).unwrap();
     xot.set_text_consolidation(true);
-    let root_clone = xot.clone(root);
+    let root_clone = xot.clone_node(root);
     assert_eq!(
         xot.to_string(root_clone).unwrap(),
         "<doc>hello <i>world</i>?!</doc>"
@@ -432,7 +432,7 @@ fn test_clone_attributes() {
     let root = xot.parse(r#"<doc><a f="F">Hello!</a></doc>"#).unwrap();
     let doc_id = xot.document_element(root).unwrap();
     let a_id = xot.first_child(doc_id).unwrap();
-    let a_id_clone = xot.clone(a_id);
+    let a_id_clone = xot.clone_node(a_id);
     // change original won't affect the clone
     xot.text_mut(xot.first_child(a_id).unwrap())
         .unwrap()
@@ -453,7 +453,7 @@ fn test_clone_namespaces() {
         .unwrap();
     let doc_id = xot.document_element(root).unwrap();
     let a_id = xot.first_child(doc_id).unwrap();
-    let a_id_clone = xot.clone(a_id);
+    let a_id_clone = xot.clone_node(a_id);
     // change original won't affect the clone
     xot.text_mut(xot.first_child(a_id).unwrap())
         .unwrap()
@@ -489,7 +489,7 @@ fn test_clone_with_namespaces() {
         .unwrap();
     let doc_id = xot.document_element(root).unwrap();
     let a_id = xot.first_child(doc_id).unwrap();
-    let a_id_clone = xot.clone(a_id);
+    let a_id_clone = xot.clone_node(a_id);
     // change original won't affect the clone
     xot.text_mut(xot.first_child(a_id).unwrap())
         .unwrap()


### PR DESCRIPTION
This PR renames `Xot::clone(&mut self, node: Node)` into `Xot::clone_node` in order to prevent confliction of the name with `Clone::clone()`, so this is a breaking change.

Closes #32.