### PR TITLE
Allow parsing of documents with standalone=no document declaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Features added
+
+- It is possible to tell the parser to accept XML documents with a `standalone=no` document
+  declaration, using function `xot.ignore_standalone_declaration`. The parser currently raises an
+  error when it encounters a document declaration stating that the document is not standalone
+  (meaning that it depends on an external resource such as a DTD or XSD schema).
+
 ### Optimizations
 
 - Use size hint to try to make string value a bit faster.

--- a/src/xotdata.rs
+++ b/src/xotdata.rs
@@ -58,6 +58,7 @@ pub struct Xot {
     pub(crate) xml_space_id: NameId,
     pub(crate) xml_id_id: NameId,
     pub(crate) text_consolidation: bool,
+    pub(crate) ignoring_standalone_declaration: bool,
 }
 
 impl Xot {
@@ -84,6 +85,7 @@ impl Xot {
             xml_space_id,
             xml_id_id,
             text_consolidation: true,
+            ignoring_standalone_declaration: false,
         }
     }
 

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -48,6 +48,17 @@ fn test_parse_xml_declaration() {
 }
 
 #[test]
+fn test_parse_xml_ignore_standalone_declaration() {
+    let mut xot = Xot::new().ignore_standalone_declaration(true);
+    let doc = xot.parse(r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><a/>"#);
+    assert!(doc.is_ok());
+
+    let mut xot = Xot::new().ignore_standalone_declaration(true);
+    let doc = xot.parse(r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?><a/>"#);
+    assert!(doc.is_ok());
+}
+
+#[test]
 fn test_encoding_lowercase_utf8() {
     let mut xot = Xot::new();
     let doc = xot.parse(r#"<?xml version="1.0" encoding="utf-8"?><a/>"#);


### PR DESCRIPTION
As per #37. Some basic tests are included. 