### PR TITLE
Ignore the value of the standalone declaration.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Features added
+
+- The parser now accepts documents with an XML declaration including `standalone=no`. These
+  documents would previously raise an `UnsupportedNotStandalone` error. The
+  `UnsupportedNotStandalone` error category is now deprecated.
+
 ### Optimizations
 
 - Use size hint to try to make string value a bit faster.

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,9 @@ pub enum ParseError {
     DuplicateAttribute(String, Span),
     /// Unsupported XML version. Only 1.0 is supported.
     UnsupportedVersion(String, Span),
-    /// Unsupported standalone declaration. Only `yes` is supported.
+    /// Unsupported standalone declaration. This error is deprecated since version 0.29, and both
+    /// "yes" and "no" values are accepted for the standalone declaration.
+    #[deprecated(since = "0.2.9", note = "The value of the standalone declaration is now ignored")]
     UnsupportedNotStandalone(Span),
     /// XML DTD is not supported.
     DtdUnsupported(Span),
@@ -44,6 +46,7 @@ impl ParseError {
             ParseError::UnknownPrefix(_, span) => *span,
             ParseError::DuplicateAttribute(_, span) => *span,
             ParseError::UnsupportedVersion(_, span) => *span,
+            #[allow(deprecated)]
             ParseError::UnsupportedNotStandalone(span) => *span,
             ParseError::DtdUnsupported(span) => *span,
             ParseError::NoElementAtTopLevel(position) => Span::new(*position, *position),
@@ -176,6 +179,7 @@ impl std::fmt::Display for ParseError {
             ParseError::UnknownPrefix(s, _) => write!(f, "Unknown prefix: {}", s),
             ParseError::DuplicateAttribute(s, _) => write!(f, "Duplicate attribute: {}", s),
             ParseError::UnsupportedVersion(s, _) => write!(f, "Unsupported version: {}", s),
+            #[allow(deprecated)]
             ParseError::UnsupportedNotStandalone(_) => write!(f, "Unsupported standalone"),
             ParseError::DtdUnsupported(_) => write!(f, "DTD is not supported"),
             ParseError::NoElementAtTopLevel(_) => write!(f, "No element at top level"),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -723,22 +723,12 @@ impl Xot {
                             span_info.add(SpanInfoKey::PiContent(node_id.into()), content.into());
                         }
                     }
-                    Declaration {
-                        version,
-                        encoding: _,
-                        standalone,
-                        span,
-                    } => {
+                    Declaration { version, .. } => {
                         if version.as_str() != "1.0" {
                             return Err(ParseError::UnsupportedVersion(
                                 version.to_string(),
                                 version.into(),
                             ));
-                        }
-                        if let Some(standalone) = standalone {
-                            if !standalone {
-                                return Err(ParseError::UnsupportedNotStandalone(span.into()));
-                            }
                         }
                     }
                     DtdStart { span, .. } => {

--- a/tests/test_parse_error.rs
+++ b/tests/test_parse_error.rs
@@ -36,16 +36,18 @@ fn test_unsupported_version() {
     assert_eq!(err.span(), (15..18).into());
 }
 
+// The order of the version, encoding and standalone attributes in the XML declaration is fixed by
+// the standard.
 #[test]
-fn test_unsupported_not_standalone() {
-    let xml = r#"<?xml version="1.0" standalone="no"?><doc></doc>"#;
+fn test_parse_invalid_xml_declaration() {
     let mut xot = Xot::new();
-    let err = xot.parse(xml).unwrap_err();
-    assert!(matches!(
-        err,
-        xot::ParseError::UnsupportedNotStandalone { .. }
-    ));
-    assert_eq!(err.span(), (0..37).into());
+    let err = xot.parse(r#"<?xml version="1.0" standalone="yes" encoding="UTF-8"?><a/>"#)
+        .unwrap_err();
+    assert!(matches!(err, xot::ParseError::XmlParser { .. }));
+    match err {
+        xot::ParseError::XmlParser(e, _) => assert!(matches!(e, xmlparser::Error::InvalidDeclaration { .. })),
+        _ => unreachable!(),
+    }
 }
 
 #[test]

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -48,6 +48,20 @@ fn test_parse_xml_declaration() {
 }
 
 #[test]
+fn test_parse_xml_standalone_yes() {
+    let mut xot = Xot::new();
+    let doc = xot.parse(r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><a/>"#);
+    assert!(doc.is_ok());
+}
+
+#[test]
+fn test_parse_xml_standalone_no() {
+    let mut xot = Xot::new();
+    let doc = xot.parse(r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?><a/>"#);
+    assert!(doc.is_ok());
+}
+
+#[test]
 fn test_encoding_lowercase_utf8() {
     let mut xot = Xot::new();
     let doc = xot.parse(r#"<?xml version="1.0" encoding="utf-8"?><a/>"#);


### PR DESCRIPTION
The parser previously raised an error when it encountered a document declaration stating that the document is not standalone (with standalone=no, meaning that it depends on an external resource such as a DTD or XSD schema). Both values of "yes" (the default if not specified) and "no" are now allowed.

The UnsupportedNotStandalone error type is no longer used, and marked as deprecated.

Fixes #37.