### PR TITLE
Add actions for msrv check and fix lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust 1.78
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.78.0"
+          profile: minimal
+          override: true
+          components: clippy, rustfmt
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-1.78-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-1.78-
+
+      - name: Build
+        run: cargo build --all-targets --locked
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Lint (deny warnings)
+        run: cargo clippy --all-targets --all-features --locked -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xot"
 version = "0.31.2"
 edition = "2021"
+rust-version = "1.78"
 license = "MIT"
 description = "Full-featured XML tree library for Rust"
 authors = ["Martijn Faassen <faassen@startifact.com>"]

--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ Xot underneath uses the
 [indextree](https://docs.rs/indextree/latest/indextree/) crate. Xot completely
 wraps the indextree functionality but the various operations it allows are
 taken from indextree.
+
+## Development
+
+To check the repository before opening a PR, run `just ci` or simply `just` in
+the repository root.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+ci: build test fmt lint
+
+build:
+  cargo build --all-targets --locked
+
+test:
+  cargo test --locked
+
+fmt:
+  cargo fmt --all -- --check
+
+lint:
+  cargo clippy --all-targets --all-features --locked -- -D warnings

--- a/src/access.rs
+++ b/src/access.rs
@@ -354,7 +354,7 @@ impl Xot {
     ///
     /// assert_eq!(attributes.get(a), Some(&"A".to_string()));
     /// ```
-    pub fn attributes(&self, node: Node) -> Attributes {
+    pub fn attributes(&self, node: Node) -> Attributes<'_> {
         Attributes::new(self, node)
     }
 
@@ -384,7 +384,7 @@ impl Xot {
     ///
     /// assert_eq!(namespaces.get(foo_prefix), Some(&foo_ns));
     /// ```
-    pub fn namespaces(&self, node: Node) -> Namespaces {
+    pub fn namespaces(&self, node: Node) -> Namespaces<'_> {
         Namespaces::new(self, node)
     }
 

--- a/src/manipulation.rs
+++ b/src/manipulation.rs
@@ -502,7 +502,7 @@ impl Xot {
     ///
     /// assert_eq!(xot.to_string(root).unwrap(), r#"<p xmlns:foo="FOO">Example</p>"#);
     /// ```
-    pub fn namespaces_mut(&mut self, node: Node) -> MutableNamespaces {
+    pub fn namespaces_mut(&mut self, node: Node) -> MutableNamespaces<'_> {
         if !self.is_element(node) {
             panic!("Node is not an element, so cannot set namespaces");
         }
@@ -541,7 +541,7 @@ impl Xot {
     ///
     /// assert_eq!(xot.to_string(root).unwrap(), r#"<p a="A">Example</p>"#);
     /// ```
-    pub fn attributes_mut(&mut self, node: Node) -> MutableAttributes {
+    pub fn attributes_mut(&mut self, node: Node) -> MutableAttributes<'_> {
         if !self.is_element(node) {
             panic!("Node is not an element, so cannot set attributes");
         }

--- a/src/nameaccess.rs
+++ b/src/nameaccess.rs
@@ -258,7 +258,7 @@ impl Xot {
     ///
     /// # Ok::<(), xot::Error>(())
     /// ```
-    pub fn name_ref(&self, name_id: NameId, context: Node) -> Result<xmlname::RefName, Error> {
+    pub fn name_ref(&self, name_id: NameId, context: Node) -> Result<xmlname::RefName<'_>, Error> {
         xmlname::RefName::from_node(self, context, name_id)
     }
 
@@ -472,7 +472,7 @@ impl Xot {
     ///
     /// # Ok::<(), xot::Error>(())
     /// ```
-    pub fn node_name_ref(&self, node: Node) -> Result<Option<xmlname::RefName>, Error> {
+    pub fn node_name_ref(&self, node: Node) -> Result<Option<xmlname::RefName<'_>>, Error> {
         if let Some(name) = self.node_name(node) {
             Ok(Some(self.name_ref(name, node)?))
         } else {
@@ -899,7 +899,7 @@ mod tests {
         let a = xot.first_child(doc_el).unwrap();
         let b = xot.first_child(a).unwrap();
 
-        let foo = xot.prefix("foo").unwrap();
+        let foo_p = xot.prefix("foo").unwrap();
         let ns = xot.namespace("http://example.com").unwrap();
         let ns_foo = xot.namespace("http://example.com/foo").unwrap();
         let ns_bar = xot.namespace("http://example.com/bar").unwrap();
@@ -907,18 +907,18 @@ mod tests {
 
         assert_eq!(
             xot.prefixes_in_scope(doc_el),
-            Prefixes::from_iter(vec![(foo, ns), (xot.xml_prefix(), xot.xml_namespace())])
+            Prefixes::from_iter(vec![(foo_p, ns), (xot.xml_prefix(), xot.xml_namespace())])
         );
 
         assert_eq!(
             xot.prefixes_in_scope(a),
-            Prefixes::from_iter(vec![(foo, ns), (xot.xml_prefix(), xot.xml_namespace())])
+            Prefixes::from_iter(vec![(foo_p, ns), (xot.xml_prefix(), xot.xml_namespace())])
         );
 
         assert_eq!(
             xot.prefixes_in_scope(b),
             Prefixes::from_iter(vec![
-                (foo, ns_foo),
+                (foo_p, ns_foo),
                 (bar, ns_bar),
                 (xot.xml_prefix(), xot.xml_namespace())
             ])

--- a/src/output/html5_serializer.rs
+++ b/src/output/html5_serializer.rs
@@ -234,7 +234,7 @@ impl<'a, N: Normalizer> Html5Serializer<'a, N> {
                         .fullname_serializer
                         .attribute_prefix(*name_id)?
                         .is_none()
-                        && local_name.to_ascii_lowercase() == value.to_ascii_lowercase()
+                        && local_name.eq_ignore_ascii_case(value)
                     {
                         return Ok(OutputToken {
                             space: true,

--- a/src/output/pretty.rs
+++ b/src/output/pretty.rs
@@ -74,7 +74,7 @@ where
     }
 
     fn in_mixed(&self) -> bool {
-        self.stack.iter().any(|e| *e == StackEntry::Mixed)
+        self.stack.contains(&StackEntry::Mixed)
     }
 
     fn in_space_preserve(&self) -> bool {

--- a/src/output/serializer.rs
+++ b/src/output/serializer.rs
@@ -34,7 +34,7 @@ pub enum Output<'a> {
     ProcessingInstruction(NameId, Option<&'a str>),
 }
 
-pub(crate) fn gen_outputs(xot: &Xot, node: Node) -> impl Iterator<Item = (Node, Output)> + '_ {
+pub(crate) fn gen_outputs(xot: &Xot, node: Node) -> impl Iterator<Item = (Node, Output<'_>)> + '_ {
     gen!({
         for edge in xot.traverse(node) {
             match edge {
@@ -56,7 +56,7 @@ pub(crate) fn gen_outputs(xot: &Xot, node: Node) -> impl Iterator<Item = (Node, 
     .into_iter()
 }
 
-fn gen_edge_start(xot: &Xot, top_node: Node, node: Node) -> impl Iterator<Item = Output> + '_ {
+fn gen_edge_start(xot: &Xot, top_node: Node, node: Node) -> impl Iterator<Item = Output<'_>> + '_ {
     gen!({
         let value = xot.value(node);
 
@@ -103,7 +103,7 @@ fn gen_edge_start(xot: &Xot, top_node: Node, node: Node) -> impl Iterator<Item =
     .into_iter()
 }
 
-fn gen_edge_end(xot: &Xot, node: Node) -> impl Iterator<Item = Output> + '_ {
+fn gen_edge_end(xot: &Xot, node: Node) -> impl Iterator<Item = Output<'_>> + '_ {
     gen!({
         let value = xot.value(node);
         if let Value::Element(element) = value {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -329,7 +329,7 @@ assert_eq!(s, "<doc>\u{1E0D}\u{0307}</doc>");
     ///
     /// If you need to generate multiple HTML 5 serializations, it's slightly
     /// more efficient not to re-create this each time.
-    pub fn html5(&mut self) -> Html5 {
+    pub fn html5(&mut self) -> Html5<'_> {
         Html5::new(self)
     }
 
@@ -348,7 +348,7 @@ assert_eq!(s, "<doc>\u{1E0D}\u{0307}</doc>");
     /// using Xot you can guarantee that the XML is well-formed, entities and
     /// namespaces have been expanded, and you have access to Xot names using
     /// familiar Xot APIs.
-    pub fn outputs(&self, node: Node) -> impl Iterator<Item = (Node, Output)> {
+    pub fn outputs(&self, node: Node) -> impl Iterator<Item = (Node, Output<'_>)> {
         gen_outputs(self, node)
     }
 

--- a/src/xmlname/reference.rs
+++ b/src/xmlname/reference.rs
@@ -20,7 +20,7 @@ pub trait NameStrInfo {
     fn prefix(&self) -> &str;
 
     /// Access the full name as a string
-    fn full_name(&self) -> Cow<str> {
+    fn full_name(&self) -> Cow<'_, str> {
         let prefix = self.prefix();
         if !prefix.is_empty() {
             Cow::Owned(format!("{}:{}", prefix, self.local_name()))

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -5,7 +5,8 @@ use xot::Xot;
 type RoundTripEntry = (&'static str, &'static str);
 
 #[rstest]
-fn roundtrip(#[values(    
+fn roundtrip(
+    #[values(
     ("basic", r#"<root><a>1</a><b>2</b></root>"#),
     ("self closing", r#"<root/>"#),
     (
@@ -28,7 +29,7 @@ fn roundtrip(#[values(
       "attribute",
       r#"<root foo="bar"/>"#,
   ),
-  ( 
+  (
       "attribute in namespace",
       r#"<root xmlns:foo="http://example.com" foo:bar="baz"/>"#,
   ),
@@ -68,7 +69,9 @@ fn roundtrip(#[values(
     "prefix stability",
     r#"<root xmlns:foo="http://example.com" xmlns:bar="http://example.com/bar"/>"#,
   )
-)] value: RoundTripEntry) {
+)]
+    value: RoundTripEntry,
+) {
     let (name, xml) = value;
     let mut xot = Xot::new();
     let doc = xot.parse(xml).unwrap();

--- a/tests/test_parse_error.rs
+++ b/tests/test_parse_error.rs
@@ -41,11 +41,14 @@ fn test_unsupported_version() {
 #[test]
 fn test_parse_invalid_xml_declaration() {
     let mut xot = Xot::new();
-    let err = xot.parse(r#"<?xml version="1.0" standalone="yes" encoding="UTF-8"?><a/>"#)
+    let err = xot
+        .parse(r#"<?xml version="1.0" standalone="yes" encoding="UTF-8"?><a/>"#)
         .unwrap_err();
     assert!(matches!(err, xot::ParseError::XmlParser { .. }));
     match err {
-        xot::ParseError::XmlParser(e, _) => assert!(matches!(e, xmlparser::Error::InvalidDeclaration { .. })),
+        xot::ParseError::XmlParser(e, _) => {
+            assert!(matches!(e, xmlparser::Error::InvalidDeclaration { .. }))
+        }
         _ => unreachable!(),
     }
 }

--- a/tests/test_traverse.rs
+++ b/tests/test_traverse.rs
@@ -76,18 +76,18 @@ fn test_reverse_preorder() {
 #[test]
 fn test_all_reverse_preorder() {
     let mut xot = Xot::new();
-    let foo = xot.add_name("foo");
+    let foo_name = xot.add_name("foo");
     let doc = xot.parse(r#"<a><b foo="FOO">text</b><c/></a>"#).unwrap();
     let a = xot.document_element(doc).unwrap();
 
     let b = xot.first_child(a).unwrap();
-    let foo = xot.attributes(b).get_node(foo).unwrap();
+    let foo_node = xot.attributes(b).get_node(foo_name).unwrap();
     let text = xot.first_child(b).unwrap();
     let c = xot.next_sibling(b).unwrap();
 
     let result = xot.all_reverse_preorder(c).collect::<Vec<_>>();
 
-    assert_eq!(result, vec![c, text, foo, b, a, doc]);
+    assert_eq!(result, vec![c, text, foo_node, b, a, doc]);
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn test_following() {
 #[test]
 fn test_all_following() {
     let mut xot = xot::Xot::new();
-    let foo = xot.add_name("foo");
+    let foo_name = xot.add_name("foo");
     let root = xot
         .parse(r#"<p><a/><b><c/><d foo="FOO"/><e/></b><f><g/><h/></f></p>"#)
         .unwrap();
@@ -139,19 +139,19 @@ fn test_all_following() {
     let b = xot.next_sibling(a).unwrap();
     let c = xot.first_child(b).unwrap();
     let d = xot.next_sibling(c).unwrap();
-    let foo = xot.attributes(d).get_node(foo).unwrap();
+    let foo_node = xot.attributes(d).get_node(foo_name).unwrap();
     let e = xot.next_sibling(d).unwrap();
     let f = xot.next_sibling(b).unwrap();
     let g = xot.first_child(f).unwrap();
     let h = xot.next_sibling(g).unwrap();
     let siblings = xot.all_following(c).collect::<Vec<_>>();
-    assert_eq!(siblings, vec![d, foo, e, f, g, h]);
+    assert_eq!(siblings, vec![d, foo_node, e, f, g, h]);
 }
 
 #[test]
 fn test_all_following2() {
     let mut xot = xot::Xot::new();
-    let foo = xot.add_name("foo");
+    let foo_name = xot.add_name("foo");
     let root = xot
         .parse(r#"<p><a/><b><c>content</c><d foo="FOO"/><e/></b><f><g/><h/></f></p>"#)
         .unwrap();
@@ -160,13 +160,13 @@ fn test_all_following2() {
     let b = xot.next_sibling(a).unwrap();
     let c = xot.first_child(b).unwrap();
     let d = xot.next_sibling(c).unwrap();
-    let foo = xot.attributes(d).get_node(foo).unwrap();
+    let foo_node = xot.attributes(d).get_node(foo_name).unwrap();
     let e = xot.next_sibling(d).unwrap();
     let f = xot.next_sibling(b).unwrap();
     let g = xot.first_child(f).unwrap();
     let h = xot.next_sibling(g).unwrap();
     let siblings = xot.all_following(c).collect::<Vec<_>>();
-    assert_eq!(siblings, vec![d, foo, e, f, g, h]);
+    assert_eq!(siblings, vec![d, foo_node, e, f, g, h]);
 }
 
 #[test]
@@ -184,7 +184,7 @@ fn test_all_following3() {
 #[test]
 fn test_all_following_attribute() {
     let mut xot = xot::Xot::new();
-    let foo = xot.add_name("foo");
+    let foo_name = xot.add_name("foo");
     let root = xot
         .parse(r#"<p><a/><b><c bar="BAR"/><d foo="FOO"/><e/></b><f><g/><h/></f></p>"#)
         .unwrap();
@@ -193,11 +193,11 @@ fn test_all_following_attribute() {
     let b = xot.next_sibling(a).unwrap();
     let c = xot.first_child(b).unwrap();
     let d = xot.next_sibling(c).unwrap();
-    let foo = xot.attributes(d).get_node(foo).unwrap();
+    let foo_node = xot.attributes(d).get_node(foo_name).unwrap();
     let e = xot.next_sibling(d).unwrap();
     let f = xot.next_sibling(b).unwrap();
     let g = xot.first_child(f).unwrap();
     let h = xot.next_sibling(g).unwrap();
     let siblings = xot.all_following(c).collect::<Vec<_>>();
-    assert_eq!(siblings, vec![d, foo, e, f, g, h]);
+    assert_eq!(siblings, vec![d, foo_node, e, f, g, h]);
 }


### PR DESCRIPTION
Sorry for not having done anything as per the xmldsig issue I opened more than a year ago!

Where I work the issue that needed that functionality got postponed due to other priorities, but came up again now. I thought I'd begin with a smaller housekeeping task if that's all right with you.

I added a Gitlab CI Action that checks whether a specific Rust MSRV still builds and added that to the Cargo.toml. I picked version 1.78 because it's the first version that supports Cargo.lock version 4 files.
It would be possible to downgrade to an earlier Rust version if the Cargo.lock version field is set to 3 - there's nothing in it that isn't version 3 incompatible. I tested various versions, but the oldest possible is 1.75 as the codebase uses RPIT syntax. What's your opinion on this?

In addition, I added a justfile that makes it easy to run the same commands locally that get executed by the Github Actions. I haven't found any better way yet to do this than adding a separate file and manually ensuring they don't diverge over time.